### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   laravel-checks:
     name: Larastan / Pint / npm / Tests


### PR DESCRIPTION
Potential fix for [https://github.com/Bjornar97/Renbot/security/code-scanning/17](https://github.com/Bjornar97/Renbot/security/code-scanning/17)

To fix the issue, we will add a `permissions` block to the workflow file. Since the workflow primarily involves reading repository contents and running tests, the minimal permissions required are `contents: read`. This ensures that the workflow has only the necessary access to repository contents while preventing unintended write access.

The `permissions` block will be added at the root level of the workflow file, applying to all jobs in the workflow. This approach is cleaner and avoids redundancy compared to adding the block to individual jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
